### PR TITLE
Initial PlatformIO and Travis support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 Settings_local.h
+.pioenvs
+.piolibdeps
+lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+python:
+    - "2.7"
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+
+git:
+    submodules: true
+
+cache:
+    directories:
+        - "~/.platformio"
+
+env:
+    - PLATFORMIO_CI_SRC=ESP32-mqtt-room.ino.ino
+
+install:
+    - pip install -U platformio
+
+before_script:
+    - cp Settings_CI.h Settings_local.h
+
+script:
+    - platformio lib update
+    - platformio run

--- a/Settings_CI.h
+++ b/Settings_CI.h
@@ -1,0 +1,10 @@
+#define ssid "Travis"
+#define password "123456789"
+#define hostname "esp32_room_presence"
+#define mqttServer "192.168.1.1"
+#define mqttPort 1883
+#define mqttUser "homeassistant"
+#define mqttPassword "123456789"
+#define room "living-room"
+#define channel "room_presence"
+#define scanInterval 15

--- a/partitions_singleapp.csv
+++ b/partitions_singleapp.csv
@@ -1,0 +1,6 @@
+# From https://github.com/espressif/esp-idf/tree/master/components/partition_table
+# Name,   Type, SubType, Offset,  Size, Flags
+# Note: if you change the phy_init or app partition offset, make sure to change the offset in Kconfig.projbuild
+nvs,      data, nvs,     ,        0x6000,
+phy_init, data, phy,     ,        0x1000,
+factory,  app,  factory, ,        2M,

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,3 +16,4 @@ platform = espressif32
 framework = arduino
 board = esp32dev
 lib_deps = PubSubClient, ArduinoJSON
+board_build.partitions = partitions_singleapp.csv

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,18 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:esp32]
+platform = espressif32
+framework = arduino
+board = esp32dev
+lib_deps = PubSubClient, ArduinoJSON


### PR DESCRIPTION
Saw your post at https://community.home-assistant.io/t/esp32-based-ble-tracking-for-mqtt-room/71309/17 and the PlatformIO chat. 

This is actually untested on real hardware as I don't have an ESP32, but it compiles on PlatformIO and Travis