### PR TITLE
Room Assistant compatibility

### DIFF
--- a/ESP32-mqtt-room.ino
+++ b/ESP32-mqtt-room.ino
@@ -305,11 +305,10 @@ class MyAdvertisedDeviceCallbacks: public BLEAdvertisedDeviceCallbacks {
 	void onResult(BLEAdvertisedDevice advertisedDevice) {
 
 		digitalWrite(LED_BUILTIN, LED_ON);
-		Serial.printf("Advertised Device: %s \n", advertisedDevice.toString().c_str());
-		if (mqttClient.connected()) {
-			reportDevice(advertisedDevice);
-		}
+		// Serial.printf("Advertised Device: %s \n", advertisedDevice.toString().c_str());
+		vTaskDelay(10 / portTICK_PERIOD_MS);
 		digitalWrite(LED_BUILTIN, !LED_ON);
+
 	}
 
 };
@@ -320,10 +319,23 @@ TaskHandle_t BLEScan;
 void scanForDevices(void * parameter) {
 	while(1) {
 		if (!updateInProgress && WiFi.isConnected() && (millis() - last > (waitTime * 1000) || last == 0)) {
-	    Serial.print("Scanning...\n");
+			// mqttClient.disconnect(true);
+			// xTimerStop(mqttReconnectTimer, 0); // ensure we don't reconnect to MQTT while reconnecting to Wi-Fi
+	    Serial.print("Scanning...\t");
 			BLEScanResults foundDevices = pBLEScan->start(scanTime);
-	    Serial.printf("Scan done! Devices found: %d\n",foundDevices.getCount());
+	    Serial.printf("Scan done! Devices found: %d\t",foundDevices.getCount());
+			// mqttClient.connect();
+			// while (!mqttClient.connected()) {
+			// 	Serial.print(".");
+			// 	vTaskDelay(10 / portTICK_PERIOD_MS);
+			// }
+			for (uint32_t i = 0; i < foundDevices.getCount(); i++) {
+				if (mqttClient.connected()) {
+					reportDevice(foundDevices.getDevice(i));
+				}
+			}
 	    last = millis();
+			Serial.println("Reports sent");
 	  }
 	}
 }

--- a/ESP32-mqtt-room.ino
+++ b/ESP32-mqtt-room.ino
@@ -234,7 +234,7 @@ void reportDevice(BLEAdvertisedDevice advertisedDevice) {
 				JSONencoder["minor"] = minor;
 
 				JSONencoder["uuid"] = proximityUUID;
-				JSONencoder["id"] = proximityUUID + "-" + String(major) + "-0";
+				JSONencoder["id"] = proximityUUID + "-" + String(major) + "-" + String(minor);
 				JSONencoder["txPower"] = oBeacon.getSignalPower();
 				JSONencoder["distance"] = distance;
 

--- a/ESP32-mqtt-room.ino
+++ b/ESP32-mqtt-room.ino
@@ -397,7 +397,7 @@ void setup() {
 
   BLEDevice::init("");
   pBLEScan = BLEDevice::getScan(); //create new scan
-  pBLEScan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks(), scanWantDuplicates);
+  pBLEScan->setAdvertisedDeviceCallbacks(new MyAdvertisedDeviceCallbacks());
   pBLEScan->setActiveScan(activeScan);
 	pBLEScan->setInterval(bleScanInterval);
 	pBLEScan->setWindow(bleScanWindow);

--- a/Settings.h
+++ b/Settings.h
@@ -40,7 +40,7 @@
 #define scanWantDuplicates false // If false then during a singleScanTime period every detected device will be reported only once
 #define activeScan true // Active scan uses more power, but get results faster
 #define bleScanInterval 0x80 // (milliseconds) The time interval from when the Controller started its last LE scan until it begins the subsequent LE scan
-#define bleScanWindow 0x80 // (milliseconds) The duration of the LE scan, shall be less than or equal to bleScanInterval; if interval and window are equal then perform continuous scan
+#define bleScanWindow 0x10 // (milliseconds) The duration of the LE scan, shall be less than or equal to bleScanInterval; if interval and window are equal then perform continuous scan
 #define advertisementDuration 3 // Define the duration in seconds that the device should advertise as a beacon to other sensors
 
 // Maximum distance (in meters) to report. Devices that are calculated to be further than this distance in meters will not be reported

--- a/Settings.h
+++ b/Settings.h
@@ -37,7 +37,6 @@
 // Define bluetooth scan parameters
 #define scanInterval 2 // Define the interval in seconds between scans
 #define singleScanTime 3 // Define the duration of a single scan in seconds
-#define scanWantDuplicates false // If false then during a singleScanTime period every detected device will be reported only once
 #define activeScan true // Active scan uses more power, but get results faster
 #define bleScanInterval 0x80 // (milliseconds) The time interval from when the Controller started its last LE scan until it begins the subsequent LE scan
 #define bleScanWindow 0x10 // (milliseconds) The duration of the LE scan, shall be less than or equal to bleScanInterval; if interval and window are equal then perform continuous scan

--- a/Settings.h
+++ b/Settings.h
@@ -36,6 +36,11 @@
 
 // Define bluetooth scan parameters
 #define scanInterval 2 // Define the interval in seconds between scans
+#define singleScanTime 3 // Define the duration of a single scan in seconds
+#define scanWantDuplicates false // If false then during a singleScanTime period every detected device will be reported only once
+#define activeScan true // Active scan uses more power, but get results faster
+#define bleScanInterval 0x80 // (milliseconds) The time interval from when the Controller started its last LE scan until it begins the subsequent LE scan
+#define bleScanWindow 0x80 // (milliseconds) The duration of the LE scan, shall be less than or equal to bleScanInterval; if interval and window are equal then perform continuous scan
 #define advertisementDuration 3 // Define the duration in seconds that the device should advertise as a beacon to other sensors
 
 // Maximum distance (in meters) to report. Devices that are calculated to be further than this distance in meters will not be reported


### PR DESCRIPTION
* changed id field of ibeacon device reports to include minor number
* moved reporting of found devices to scanner callback - Room Assistant sends them right away without waiting for the scanner to finish; this also allows us to enable wantDuplicates flag to report a device multiple times during single scan, every time it's detected
* extracted more scanner parameters to settings file